### PR TITLE
Update configure-module to bind user domains

### DIFF
--- a/imageroot/actions/configure-module/10configure_environment_vars
+++ b/imageroot/actions/configure-module/10configure_environment_vars
@@ -13,7 +13,11 @@ import agent
 # If parsing fails, output everything to stderr
 data = json.load(sys.stdin)
 
-agent.set_env("LDAP_DOMAIN", data.get("ldap_domain", ""))
-agent.set_env("AUTH_METHOD", 'BASIC' if data.get("ldap_domain", "basic") == "basic" else 'LDAP')
+agent.set_env("LDAP_DOMAIN", data["ldap_domain"])
+agent.set_env("AUTH_METHOD", 'BASIC' if data["ldap_domain"] == "basic" else 'LDAP')
 agent.set_env("AUTH_PASS", data.get("auth_pass", ""))
 agent.set_env("AUTH_USER", data.get("auth_user", ""))
+
+# bind to the user domain
+if data["ldap_domain"] != "basic":
+    agent.bind_user_domains([data["ldap_domain"]])


### PR DESCRIPTION
This pull request updates the configure-module script to bind user domains when the LDAP domain is not set to "basic". This change enhances the security and access control for the module.