### PR TITLE
Add volumes/logs to state-include.conf and backuppc-app.service

### DIFF
--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -6,3 +6,4 @@
 
 
 volumes/data
+volumes/logs

--- a/imageroot/systemd/user/backuppc-app.service
+++ b/imageroot/systemd/user/backuppc-app.service
@@ -30,6 +30,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/backuppc-app.pid \
     --volume ./conf/etc/:/etc/backuppc:Z \
     --volume ./conf/home/:/home/backuppc:Z \
     --volume ./conf/home/:/home/backuppc:Z \
+    --volume logs:/www/logs:Z \
     --env NGINX_AUTHENTICATION_TYPE=${AUTH_METHOD} \
     --env NGINX_AUTHENTICATION_BASIC_USER1=${AUTH_USER} \
     --env NGINX_AUTHENTICATION_BASIC_PASS1=${AUTH_PASS} \


### PR DESCRIPTION
This pull request adds the `volumes/logs` entry to the `state-include.conf` file and includes the `--volume logs:/www/logs:Z` option in the `backuppc-app.service` systemd unit file. This change ensures that the logs directory is included in the backup and properly mounted for the BackupPC application.