### PR TITLE
Update metadata.json with correct author information and documentation URLs

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -1,19 +1,19 @@
 {
   "name": "backuppc",
   "description": {
-    "en": "My backuppc module"
+    "en": "BackupPC is a high-performance, enterprise-grade system for backing up desktops and laptops to a server's disk"
   },
-  "categories": [],
+  "categories": ["storage"],
   "authors": [
     {
-      "name": "Name Surname",
-      "email": "author@yourmail.org"
+      "name": "stephane de Labrusse",
+      "email": "stephdl@de-labrusse.fr"
     }
   ],
   "docs": {
-    "documentation_url": "https://docs.backuppc.com/",
-    "bug_url": "https://github.com/NethServer/dev",
-    "code_url": "https://github.com/author/ns8-backuppc"
+    "documentation_url": "https://backuppc.github.io/backuppc/BackupPC.html",
+    "bug_url": "https://github.com/stephdl/dev",
+    "code_url": "https://github.com/stephdl/ns8-backuppc"
   },
-  "source": "ghcr.io/nethserver/backuppc"
+  "source": "ghcr.io/stephdl/backuppc"
 }


### PR DESCRIPTION
This pull request updates the metadata.json file to correct the author information and documentation URLs. The author name is changed to "Stephane de Labrusse" with the email "stephdl@de-labrusse.fr". The documentation URL is updated to "https://backuppc.github.io/backuppc/BackupPC.html". These changes ensure accurate attribution and provide the correct documentation resource for the BackupPC module.