### PR TITLE
Include state/conf directory in backup

### DIFF
--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -7,3 +7,4 @@
 
 volumes/data
 volumes/logs
+state/conf

--- a/imageroot/systemd/user/backuppc-app.service
+++ b/imageroot/systemd/user/backuppc-app.service
@@ -29,7 +29,6 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/backuppc-app.pid \
     --volume data:/var/lib/backuppc:Z \
     --volume ./conf/etc/:/etc/backuppc:Z \
     --volume ./conf/home/:/home/backuppc:Z \
-    --volume ./conf/home/:/home/backuppc:Z \
     --volume logs:/www/logs:Z \
     --env NGINX_AUTHENTICATION_TYPE=${AUTH_METHOD} \
     --env NGINX_AUTHENTICATION_BASIC_USER1=${AUTH_USER} \


### PR DESCRIPTION
This pull request includes changes to the `state-include.conf` file and the `backuppc-app.service` file. The `state/conf` directory is added to the `state-include.conf` file to ensure it is included in the backup for the BackupPC application. Additionally, the duplicate volume mapping in the `backuppc-app.service` file has been removed.