### PR TITLE
Include volumes/conf and volumes/home in backup

### DIFF
--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -7,4 +7,5 @@
 
 volumes/data
 volumes/logs
-state/conf
+volumes/conf
+volumes/home

--- a/imageroot/systemd/user/backuppc-app.service
+++ b/imageroot/systemd/user/backuppc-app.service
@@ -17,8 +17,6 @@ ExecStartPre=/usr/local/bin/runagent discover-ldap
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70
-ExecStartPre=/bin/mkdir -p ./conf/etc
-ExecStartPre=/bin/mkdir -p ./conf/home
 ExecStartPre=/bin/rm -f %t/backuppc-app.pid %t/backuppc-app.ctr-id
 ExecStartPre=-runagent discover-smarthost
 ExecStartPre=/usr/local/bin/runagent discover-ldap
@@ -27,8 +25,8 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/backuppc-app.pid \
     --pod-id-file %t/backuppc.pod-id --replace -d --name  backuppc-app \
     --cap-add NET_RAW \
     --volume data:/var/lib/backuppc:Z \
-    --volume ./conf/etc/:/etc/backuppc:Z \
-    --volume ./conf/home/:/home/backuppc:Z \
+    --volume conf:/etc/backuppc:Z \
+    --volume home:/home/backuppc:Z \
     --volume logs:/www/logs:Z \
     --env NGINX_AUTHENTICATION_TYPE=${AUTH_METHOD} \
     --env NGINX_AUTHENTICATION_BASIC_USER1=${AUTH_USER} \


### PR DESCRIPTION
This pull request updates the state-include.conf file to include the volumes/conf and volumes/home directories in the backup for the BackupPC application. This ensures that important configuration files and user data are included in the backup. Additionally, the backuppc-app.service file is modified to remove the creation of the ./conf/etc and ./conf/home directories and instead use the conf and home volumes for mounting the respective directories.