### PR TITLE
No smtp authentication is off not none

### DIFF
--- a/imageroot/bin/discover-smarthost
+++ b/imageroot/bin/discover-smarthost
@@ -23,7 +23,7 @@ with open(envfile + ".tmp", "w") as efp:
     print(f"SMTP_ENABLED={'1' if smtp_settings['enabled'] else ''}", file=efp)
     print(f"SMTP_HOST={smtp_settings['host']}", file=efp)
     print(f"SMTP_PORT={smtp_settings['port']}", file=efp)
-    print(f"SMTP_AUTHENTICATION={'on' if authentication else 'none'}", file=efp)
+    print(f"SMTP_AUTHENTICATION={'on' if authentication else 'off'}", file=efp)
     print(f"SMTP_USER={smtp_settings['username']}", file=efp)
     print(f"SMTP_FROM={smtp_settings['username']}", file=efp)
     print(f"SMTP_PASS={smtp_settings['password']}", file=efp)


### PR DESCRIPTION
See https://community.nethserver.org/t/backuppc-invalid-configuration-for-sending-mail/24636/17

PR done upstream to documentation: https://github.com/tiredofit/docker-backuppc/pull/23