### PR TITLE
Remove data entry from state-include.conf

### DIFF
--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -5,7 +5,6 @@
 # List here what you want to save during backup : volumes or file Path
 
 
-volumes/data
 volumes/logs
 volumes/conf
 volumes/home


### PR DESCRIPTION
Eliminate the data entry from the state-include configuration to streamline the backup process.