### PR TITLE
Restrict admin CGI access to administrator users

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ You can retrieve the configuration with
 ```
 api-cli run get-configuration --agent module/backuppc1
 ```
+
+
+## Administrator of the CGI user interface
+
+By default, only `backuppc` and `administrator` are granted administrative privileges in the CGI UI. If you want to add more users, you can define them in the `$Conf{CgiAdminUsers}` setting (Edit config > CGI). For more details, see the [BackupPC Documentation](https://backuppc.github.io/backuppc/BackupPC.html#_conf_cgiadminusers_).
+
+Currently, it is not possible to read the LDAP group name; you must declare all administrators by their username or login.
+
 ## test email
 
 Once the mail notification is configured in the cluster, the BackupPC module can send emails. You can test this by sending an email using the command line.

--- a/imageroot/bin/expand-configuration
+++ b/imageroot/bin/expand-configuration
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# expand file configuration for backuppc
+set -e
+
+# Redirect any output to the journal (stderr)
+exec 1>&2
+
+# nginx configuration file
+CONFIG_FILE="../conf.d/backuppc.conf"
+
+mkdir -p ../conf.d
+
+# Choose the template based on the LDAP_DOMAIN value
+if [[ "$LDAP_DOMAIN" != "basic" ]]; then
+    TEMPLATE='server {
+    auth_ldap "Please login";
+    auth_ldap_servers ldapserver;
+    ### Do not Touch This
+    listen 80;
+    server_name localhost;
+    root /www/html;
+    ###
+
+    index /index.cgi;
+
+    location / {
+        location ~ \.cgi$ {
+            include fastcgi_params;
+            fastcgi_pass unix:/var/run/fcgiwrap.sock;
+
+            ## Always force backuppc
+            fastcgi_param REMOTE_ADDR     $remote_addr;
+            fastcgi_param REMOTE_USER     $remote_user;
+            fastcgi_param SCRIPT_FILENAME /www/cgi-bin/BackupPC/BackupPC_Admin;
+        }
+    }
+
+    ### Do not edit past here
+    include /etc/nginx/snippets/site_optimization.conf;
+    include /etc/nginx/snippets/exploit_protection.conf;
+}
+'
+else
+    TEMPLATE='server {
+    auth_basic "Please login";
+    auth_basic_user_file /etc/nginx/snippets/authentication/basic_authorized_users;
+      ### Do not Touch This
+      listen 80;
+      server_name localhost;
+      root /www/html;
+      ###
+
+      index /index.cgi;
+
+      location / {
+    	  location ~ \.cgi$ {
+	        include fastcgi_params;
+	        fastcgi_pass unix:/var/run/fcgiwrap.sock;
+
+          ## Always force backuppc
+	        fastcgi_param REMOTE_ADDR     $remote_addr;
+	        fastcgi_param REMOTE_USER     backuppc;
+	        fastcgi_param SCRIPT_FILENAME /www/cgi-bin/BackupPC/BackupPC_Admin;
+        }
+      }
+
+      ### Do not edit past here
+      include /etc/nginx/snippets/site_optimization.conf;
+      include /etc/nginx/snippets/exploit_protection.conf;
+}
+'
+fi
+
+# Write the chosen template to the config file
+echo "$TEMPLATE" > "$CONFIG_FILE"
+
+echo "Configuration file created at $CONFIG_FILE"

--- a/imageroot/bin/update-configuration
+++ b/imageroot/bin/update-configuration
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# expand file configuration for backuppc
+set -e
+
+# Redirect any output to the journal (stderr)
+exec 1>&2
+
+
+/usr/bin/podman exec backuppc-app sed -i "s/\\\$Conf{CgiAdminUsers} = 'backuppc';/\\\$Conf{CgiAdminUsers} = 'backuppc administrator';/g" /etc/backuppc/config.pl

--- a/imageroot/bin/wait-startup
+++ b/imageroot/bin/wait-startup
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# expand file configuration for backuppc
+set -e
+
+# Redirect any output to the journal (stderr)
+exec 1>&2
+# Name of the container and path to check
+CONTAINER_NAME="backuppc-app"
+FILE_PATH="/etc/backuppc/config.pl"
+
+# Count from 1 to 60 with a 1-second interval between each number
+for i in {1..60}; do
+    echo "Count: $i"
+
+    # Check if the file exists in the container
+    if podman exec "$CONTAINER_NAME" test -f "$FILE_PATH"; then
+        echo "File $FILE_PATH found in the container. Exiting."
+        exit 0
+    fi
+
+    # Wait for 1 second before the next iteration
+    sleep 1
+    echo "Waiting for the file $FILE_PATH to be created in the container.: $i seconds"
+done

--- a/imageroot/systemd/user/backuppc-app.service
+++ b/imageroot/systemd/user/backuppc-app.service
@@ -36,7 +36,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/backuppc-app.pid \
     --env SMTP_* \
     --env NGINX_* \
     ${BACKUPPC_IMAGE}
-ExecStartPost=podman exec backuppc-app sed -i "s/\$Conf{CgiAdminUsers} = 'backuppc';/\$Conf{CgiAdminUsers} = 'backuppc administrator';/g" /etc/backuppc/config.pl
+ExecStartPost=podman exec backuppc-app sed -i "s/\\\$Conf{CgiAdminUsers} = 'backuppc';/\\\$Conf{CgiAdminUsers} = 'backuppc administrator';/g" /etc/backuppc/config.pl
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/backuppc-app.ctr-id -t 10
 ExecReload=/usr/bin/podman kill -s HUP backuppc-app
 SyslogIdentifier=%u

--- a/imageroot/systemd/user/backuppc-app.service
+++ b/imageroot/systemd/user/backuppc-app.service
@@ -17,7 +17,7 @@ WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/backuppc-app.pid %t/backuppc-app.ctr-id
-ExecStartPre=-runagent discover-smarthost
+ExecStartPre=-/usr/local/bin/runagent discover-smarthost
 ExecStartPre=/usr/local/bin/runagent discover-ldap
 ExecStartPre=/usr/local/bin/runagent expand-configuration
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/backuppc-app.pid \
@@ -36,7 +36,8 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/backuppc-app.pid \
     --env SMTP_* \
     --env NGINX_* \
     ${BACKUPPC_IMAGE}
-ExecStartPost=podman exec backuppc-app sed -i "s/\\\$Conf{CgiAdminUsers} = 'backuppc';/\\\$Conf{CgiAdminUsers} = 'backuppc administrator';/g" /etc/backuppc/config.pl
+ExecStartPost=/usr/local/bin/runagent ../bin/wait-startup
+ExecStartPost=/usr/local/bin/runagent ../bin/update-configuration
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/backuppc-app.ctr-id -t 10
 ExecReload=/usr/bin/podman kill -s HUP backuppc-app
 SyslogIdentifier=%u

--- a/imageroot/systemd/user/backuppc-app.service
+++ b/imageroot/systemd/user/backuppc-app.service
@@ -19,6 +19,7 @@ TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/backuppc-app.pid %t/backuppc-app.ctr-id
 ExecStartPre=-runagent discover-smarthost
 ExecStartPre=/usr/local/bin/runagent discover-ldap
+ExecStartPre=/usr/local/bin/runagent expand-configuration
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/backuppc-app.pid \
     --cidfile %t/backuppc-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/backuppc.pod-id --replace -d --name  backuppc-app \
@@ -27,6 +28,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/backuppc-app.pid \
     --volume conf:/etc/backuppc:Z \
     --volume home:/home/backuppc:Z \
     --volume logs:/www/logs:Z \
+    --volume %S/conf.d/backuppc.conf:/etc/nginx/sites.available/backuppc.conf:Z \
     --env NGINX_AUTHENTICATION_TYPE=${AUTH_METHOD} \
     --env NGINX_AUTHENTICATION_BASIC_USER1=${AUTH_USER} \
     --env NGINX_AUTHENTICATION_BASIC_PASS1=${AUTH_PASS} \
@@ -34,6 +36,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/backuppc-app.pid \
     --env SMTP_* \
     --env NGINX_* \
     ${BACKUPPC_IMAGE}
+ExecStartPost=podman exec backuppc-app sed -i "s/\$Conf{CgiAdminUsers} = 'backuppc';/\$Conf{CgiAdminUsers} = 'backuppc administrator';/g" /etc/backuppc/config.pl
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/backuppc-app.ctr-id -t 10
 ExecReload=/usr/bin/podman kill -s HUP backuppc-app
 SyslogIdentifier=%u


### PR DESCRIPTION
Introduce a script to generate NGINX configuration based on the LDAP_DOMAIN and update the systemd service to execute this script. 

Additionally, modify the CgiAdminUsers setting to include the administrator, other users will see only their backup